### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app/ucase/chat/files.py
+++ b/app/ucase/chat/files.py
@@ -18,10 +18,21 @@ async def chat_with_files(
     x_session: str = Depends(session_middleware),
     authorization: HTTPAuthorizationCredentials = Depends(auth.authenticate)) -> IGetResponseBase:
     
-    if not os.path.exists(UPLOAD_MODEL_DIR+"/"+x_session):
-        os.makedirs(UPLOAD_MODEL_DIR+"/"+x_session)
+    session_path = os.path.normpath(os.path.join(UPLOAD_MODEL_DIR, x_session))
+    if not session_path.startswith(UPLOAD_MODEL_DIR):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, 
+            detail="Invalid session path"
+        )
+    if not os.path.exists(session_path):
+        os.makedirs(session_path)
 
-    file_path = os.path.join(UPLOAD_MODEL_DIR, file.filename)
+    file_path = os.path.normpath(os.path.join(session_path, file.filename))
+    if not file_path.startswith(session_path):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, 
+            detail="Invalid file path"
+        )
     with open(file_path, "wb") as f:
         f.write(await file.read())
 


### PR DESCRIPTION
Potential fix for [https://github.com/sofyan48/ochabot/security/code-scanning/3](https://github.com/sofyan48/ochabot/security/code-scanning/3)

To fix the problem, we need to ensure that the path constructed from user input is safe. This can be achieved by normalizing the path and ensuring it is contained within a predefined root directory. We will:
1. Normalize the path using `os.path.normpath`.
2. Check that the normalized path starts with the root directory (`UPLOAD_MODEL_DIR`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
